### PR TITLE
Update distros.json

### DIFF
--- a/data/distros.json
+++ b/data/distros.json
@@ -38,7 +38,7 @@
     "ubuntu": {
         "title": "Ubuntu",
         "address": "https://www.ubuntu.com/download/desktop/contribute",
-        "tagline": "Linux for Human Beings",
+        "tagline": "Fast, secure and simple, Ubuntu powers millions of PCs worldwide",
         "store": "https://shop.canonical.com/"
     },
     "ubuntu-mate": {


### PR DESCRIPTION
Modify the tagline for Ubuntu. We haven't used the 'Linux for human beings' line for a while. The text I've proposed comes directly from the Ubuntu home page. Hope it's okay and it fits the space.